### PR TITLE
Avoid security manager

### DIFF
--- a/Log4jHotPatch.java
+++ b/Log4jHotPatch.java
@@ -186,13 +186,9 @@ public class Log4jHotPatch {
             "or otherwise changed the package name for log4j classes, then this tool may not " +
             "find them.");
       }
-
-      inst.removeTransformer(transformer);
+    } else {
+      inst.addTransformer(transformer, false);
     }
-
-    // Re-add the transformer with 'canRetransform' set to false
-    // for class instances which might get loaded in the future.
-    inst.addTransformer(transformer, false);
 
     System.setProperty(LOG4J_FIXER_AGENT_VERSION, String.valueOf(log4jFixerAgentVersion));
   }

--- a/Log4jHotPatch.java
+++ b/Log4jHotPatch.java
@@ -204,18 +204,16 @@ public class Log4jHotPatch {
   }
 
   static class MethodInstrumentorClassVisitor extends ClassVisitor {
-    private int asm;
 
     public MethodInstrumentorClassVisitor(int asm, ClassVisitor cv) {
       super(asm, cv);
-      this.asm = asm;
     }
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
       MethodVisitor mv = cv.visitMethod(access, name, desc, signature, exceptions);
       if ("lookup".equals(name)) {
-        mv = new MethodInstrumentorMethodVisitor(asm, mv);
+        mv = new MethodInstrumentorMethodVisitor(api, mv);
       }
       return mv;
     }


### PR DESCRIPTION
This patch modifies `AccessController` to temporarily ignore security manager checks which can fail in very restricted environments, as when setting properties. It also avoids reflection.