### PR TITLE
Fix JDK 8 command line in README.md (fixes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Depending on the platform you are building. This will generate `build/libs/Log4j
 
 JDK 8
 ```
-java -cp <java-home>/lib/tools.jar:Log4jHotPatch.jar <java-pid>
+java -cp <java-home>/lib/tools.jar:Log4jHotPatch.jar Log4jHotPatch <java-pid>
 ```
 
 JDK 11 and newer


### PR DESCRIPTION
Fix trivial issue in the documentation on how to run the tool with JDK 8 (see #23). 