### PR TITLE
Avoids reinstalling the agent after retransformation of loaded classes.

### DIFF
--- a/src/main/java/Log4jHotPatch.java
+++ b/src/main/java/Log4jHotPatch.java
@@ -126,7 +126,9 @@ public class Log4jHotPatch {
         }
       };
 
-    if (!staticAgent) {
+    if (staticAgent) {
+      inst.addTransformer(transformer);
+    } else {
       int patchesApplied = 0;
 
       inst.addTransformer(transformer, true);
@@ -150,13 +152,8 @@ public class Log4jHotPatch {
             "or otherwise changed the package name for log4j classes, then this tool may not " +
             "find them.");
       }
-
-      inst.removeTransformer(transformer);
     }
 
-    // Re-add the transformer with 'canRetransform' set to false
-    // for class instances which might get loaded in the future.
-    inst.addTransformer(transformer, false);
     agentLoaded = true;
   }
 


### PR DESCRIPTION
This closes a short hole where classes might get loaded after retransformation and transformer removal but before the new transformer is added. Also, it keeps the patch intact if a Jndi lookup class is retransformed by another agent.