### PR TITLE
Remove version string output

### DIFF
--- a/src/main/java/Log4jHotPatch.java
+++ b/src/main/java/Log4jHotPatch.java
@@ -233,7 +233,6 @@ public class Log4jHotPatch {
 
   public static void main(String args[]) throws Exception {
     verbose = Boolean.parseBoolean(System.getProperty(LOG4J_FIXER_VERBOSE, "true"));
-    log("Version: " + Log4jHotPatch.class.getPackage().getImplementationVersion());
 
     String pid[];
     if (args.length == 0) {


### PR DESCRIPTION
Remove the part where we mention the version of Log4jHotPatch until we move to a package that can use the Manifest one