### PR TITLE
Log to stderr instead of stdout

### DIFF
--- a/build-tools/bin/run_tests.sh
+++ b/build-tools/bin/run_tests.sh
@@ -25,7 +25,7 @@ function start_target() {
   shift 1
 
   pushd "${ROOT_DIR}/test"
-  ${jdk_dir}/bin/java  -cp log4j-core-2.12.1.jar:log4j-api-2.12.1.jar:. $* Vuln > /tmp/vuln.log &
+  ${jdk_dir}/bin/java  -cp log4j-core-2.12.1.jar:log4j-api-2.12.1.jar:. $* Vuln > /tmp/vuln.log 2> /tmp/vuln.log &
   popd
 
   sleep 2

--- a/src/main/java/Log4jHotPatch.java
+++ b/src/main/java/Log4jHotPatch.java
@@ -58,7 +58,7 @@ public class Log4jHotPatch {
 
   private static void log(String message) {
     if (verbose) {
-      System.out.println(message);
+      System.err.println(message);
     }
   }
 
@@ -260,7 +260,7 @@ public class Log4jHotPatch {
         log("Patching all JVMs!");
       }
     } else if (args.length == 1 && ("-h".equals(args[0]) || "-help".equals(args[0]) || "--help".equals(args[0]))) {
-      System.out.println("usage: Log4jHotPatch [<pid> [<pid> ..]]");
+      System.err.println("usage: Log4jHotPatch [<pid> [<pid> ..]]");
       System.exit(1);
       return;
     } else {


### PR DESCRIPTION
Ensures any log messages from the hot patch are separate from any user program output that may be being used elsewhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
