### PR TITLE
Make it possible to version, upgrade and undo patches in the agent.

### DIFF
--- a/src/main/java/Log4jHotPatch.java
+++ b/src/main/java/Log4jHotPatch.java
@@ -281,7 +281,7 @@ public class Log4jHotPatch {
     boolean verbose = args == null || !args.contains("log4jFixerVerbose=false");
     if (agentLoaded) {
       logger.setVerbose(verbose);
-      logger.log("Info: HotPatch agent already loaded");
+      logger.log("Info: hot patch agent already loaded");
     } else {
       logger = new SimpleLogger(verbose);
       logger.log("Loading Java Agent version " + log4jFixerAgentVersion);


### PR DESCRIPTION
This is a POC and work in progress! I haven't updated the file layout so the build and tests didn't had to be changed as well. All the tests except the security manager test pass (and I hope we can make the latter pass as well).

In general, this PR should be merged with the file layout and refactoring changes of #39.

The ideas behind this change is as follows:
- Divide the agent into a bare minimum agent part, a "payload" part (i.e. a "patcher" or "transformer") and a driver which injects the agent together with a "patcher" into the target VM.
- The agent uses a custom class loader to load the payload (i.e. the transformers) which implements the `Patcher` interface.
- The agent manages the transformers  through the general `Patcher` interface methods `install()`,`uninstall()` and `getVersion()`
- calling `install()` on a `Patcher` will register all its transformers and retransform the affected classes in the dynamic use case
- calling `uninstall()`on a `Patcher` will unregister its transformers and retransform the previously transformed classes back to their initial state.

The current change contains three patchers, `EmptyPatcher`, `PatcherV1` and `PatcherV2` which all implement `Patcher`. `EmptyPatcher` is special in that it contains no functionality and has version number "0". `PatcherV1` and `PatcherV2` both implement the current Log4j patch with version numbers "1" and "2" respectively.

The main driver (i.e. `Log4jHotPatch.main()`) has a hard-coded version of the patcher it will deploy. This is currently  `PatcherV1` for testing reason. In reality this should be the latest patcher (i.e. the one with the highest version number). The driver attaches the target JVM and checks for the version of the transformer it already has. If there's no transfomer installed or if the transformer in the target JVM is smaller than the current transformer in the driver, the driver will deploy its transformer into the target. In the target this will trigger uninstallation of the old transformer and installation of the new one.

`EmptyPatcher` (i.e. version "0") is treated special in the driver. It can be used to overwrite any installed transformer in the target, effectively undoing all previous transformations. This can be used to "downgrade" the transformer e.g. by going from "2" to "0" to "1".

Apart from deploying the "default" transformer, the driver can be configured to deploy any available transformer by specifying its name with the `patcherClassName` property on the command line (e.g. `-D'patcherClassName=Log4jHotPatch$PatcherV1'`).

Because all references to the custom class loaders and transformer are deleted in the agent once a new transformer will be installed, the old ones can be collected and unloaded by the JVM.  