### PR TITLE
Close `BufferedReader` after usage

### DIFF
--- a/src/main/java/Log4jHotPatch.java
+++ b/src/main/java/Log4jHotPatch.java
@@ -250,8 +250,11 @@ public class Log4jHotPatch {
       }
       if (false && count > 0) {
         log("Patch all JVMs? (y/N) : ");
-        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-        String answer = in.readLine();
+        String answer;
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
+          answer = in.readLine();
+        }
+
         if (!"y".equals(answer)) {
           System.exit(1);
           return;


### PR DESCRIPTION
*Description of changes:*
This change will close the BufferedReader after it's usage is complete. This would prevent memory leaks. 

(I understand that this is not a major problem because the patch doesn't consume much heap and has a short lived duration but nevertheless, fixing this doesn't hurt).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
